### PR TITLE
Rename gui to observer

### DIFF
--- a/src/main/java/usecases/Gui.kt
+++ b/src/main/java/usecases/Gui.kt
@@ -1,8 +1,0 @@
-package usecases
-
-interface Gui {
-
-    fun validation_failed(errors: ValidationErrors)
-    fun createSucceeded(id: String)
-
-}

--- a/src/main/java/usecases/create_project.kt
+++ b/src/main/java/usecases/create_project.kt
@@ -1,12 +1,20 @@
 package usecases
 
-fun create_project(name: String, gui: Gui, repo: ProjectRepository) {
-    if (repo.findByName(name) != null) {
-        gui.validation_failed(ValidationErrors(listOf(mapOf("field" to "name", "validation" to "unique"))))
-    } else if (name.isEmpty()) {
-        gui.validation_failed(ValidationErrors(listOf(mapOf("field" to "name", "validation" to "required"))))
-    } else {
-        val project = repo.save(name)
-        gui.createSucceeded(project.name)
+object create_project {
+
+    interface Observer {
+        fun validation_failed(errors: ValidationErrors)
+        fun createSucceeded(id: String)
+    }
+
+    operator fun invoke(name: String, observer: Observer, repo: ProjectRepository) {
+        if (repo.findByName(name) != null) {
+            observer.validation_failed(ValidationErrors(listOf(mapOf("field" to "name", "validation" to "unique"))))
+        } else if (name.isEmpty()) {
+            observer.validation_failed(ValidationErrors(listOf(mapOf("field" to "name", "validation" to "required"))))
+        } else {
+            val project = repo.save(name)
+            observer.createSucceeded(project.name)
+        }
     }
 }

--- a/src/main/java/web/ProjectsController.kt
+++ b/src/main/java/web/ProjectsController.kt
@@ -77,7 +77,7 @@ class FindProjectsObserver {
     var projects: List<Project> = listOf()
 }
 
-class CreateProjectObserver : Gui {
+class CreateProjectObserver : create_project.Observer {
     var view: String = ""
 
     override fun validation_failed(errors: ValidationErrors) {

--- a/src/test/java/usecases/CreateProjectObserverSpy.kt
+++ b/src/test/java/usecases/CreateProjectObserverSpy.kt
@@ -2,7 +2,7 @@ package usecases
 
 import java.util.*
 
-class GuiSpy() : Gui {
+class CreateProjectObserverSpy() : create_project.Observer {
 
     override fun createSucceeded(id: String) {
         createSucceededCalls.add(id)

--- a/src/test/java/usecases/ProjectRepositoryTest.kt
+++ b/src/test/java/usecases/ProjectRepositoryTest.kt
@@ -1,6 +1,5 @@
 package usecases
 
-import org.assertj.core.api.KotlinAssertions
 import org.assertj.core.api.KotlinAssertions.assertThat
 import org.junit.Test
 

--- a/src/test/java/usecases/ProjectTest.kt
+++ b/src/test/java/usecases/ProjectTest.kt
@@ -7,8 +7,8 @@ class ProjectTest {
 
     @Test
     fun name_is_required() {
-        val guiSpy = GuiSpy()
-        create_project(name = "", gui = guiSpy, repo = InMemoryProjectRepository())
+        val guiSpy = CreateProjectObserverSpy()
+        create_project(name = "", observer = guiSpy, repo = InMemoryProjectRepository())
 
         assertThat(guiSpy.validationFailedCalls).asList().contains(mapOf("field" to "name", "validation" to "required"))
         assertThat(guiSpy.validationFailedCalls.size).isEqualTo(1)
@@ -17,9 +17,9 @@ class ProjectTest {
 
     @Test
     fun save_and_retrieve() {
-        val guiSpy = GuiSpy()
+        val guiSpy = CreateProjectObserverSpy()
         val repo = InMemoryProjectRepository()
-        create_project(name = "A project name", gui = guiSpy, repo = repo)
+        create_project(name = "A project name", observer = guiSpy, repo = repo)
 
         assertThat(guiSpy.createSucceededCalls.size).isEqualTo(1)
         assertThat(guiSpy.validationFailedCalls.size).isEqualTo(0)
@@ -30,10 +30,10 @@ class ProjectTest {
     @Test
     fun name_is_unique() {
         val repo = InMemoryProjectRepository()
-        create_project(name = "A project name", gui = GuiSpy(), repo = repo)
+        create_project(name = "A project name", observer = CreateProjectObserverSpy(), repo = repo)
 
-        val guiSpy = GuiSpy()
-        create_project(name = "A project name", gui = guiSpy, repo = repo)
+        val guiSpy = CreateProjectObserverSpy()
+        create_project(name = "A project name", observer = guiSpy, repo = repo)
 
         assertThat(guiSpy.validationFailedCalls).asList().contains(mapOf("field" to "name", "validation" to "unique"))
         assertThat(guiSpy.validationFailedCalls.size).isEqualTo(1)

--- a/src/test/java/web/ProjectsControllerTest.kt
+++ b/src/test/java/web/ProjectsControllerTest.kt
@@ -1,18 +1,16 @@
 package web
 
-import org.assertj.core.api.KotlinAssertions
 import org.assertj.core.api.KotlinAssertions.assertThat
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Before
 import org.junit.Test
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import usecases.InMemoryProjectRepository
 import usecases.ProjectRepository
+import usecases.create_project
 
 class ProjectsControllerTest() {
 


### PR DESCRIPTION
[By Mark]

LAST TIME ON EXPERIMENTAL KOTLIN LUNCH:

Previously we had CreateProjectObserver implement Gui.
There was discussion about renaming our usage of Gui to Observer, so I took a crack at it.
Switching Gui to Observer meant that we had a naming overload
where a class had the same name as the interface it was trying
to implement. (CreateProjectObserver : CreateProjectObserver).

I took a stab at namespacing the interface under the create_project
function in the similar manner as this post suggest:
https://www.novoda.com/blog/better-class-naming/

P.S. This seems to be moving away from an "intent" based naming strategy and towards a "pattern object fulfills" strategy. Anyone have any names besides Observer? Is having it included in the create_project namespace enough?
